### PR TITLE
Support TCK requirement [tck-id-message-flow-phid-sparkplug-clean-session-50]: MQTT 5.0 CONNECT must set Clean Start = true and Session Expiry Interval = 0

### DIFF
--- a/src/main/java/org/thinghsboard/sparkplug/config/SparkplugNodeConfiguration.java
+++ b/src/main/java/org/thinghsboard/sparkplug/config/SparkplugNodeConfiguration.java
@@ -47,6 +47,9 @@ public class SparkplugNodeConfiguration {
         options.setAutomaticReconnect(true);
         options.setConnectionTimeout(30);
         options.setKeepAliveInterval(30);
+        if (options.getMqttVersion() == 5) {
+            options.setSessionExpiryInterval(0L);
+        }
         return options;
     }
 }

--- a/src/main/java/org/thinghsboard/sparkplug/util/SparkplugTopicUtil.java
+++ b/src/main/java/org/thinghsboard/sparkplug/util/SparkplugTopicUtil.java
@@ -25,6 +25,15 @@ public class SparkplugTopicUtil {
 
     private static final Map<String, String[]> SPLIT_TOPIC_CACHE = new HashMap<String, String[]>();
     private static final String TOPIC_INVALID_NUMBER = "Invalid number of topic elements: ";
+    /**
+     * https://www.eclipse.org/tahu/spec/sparkplug_spec.pdf
+     * [tck-id-topic-structure-namespace-a] For the Sparkplug B version of the payload definition, the
+     * UTF-8 string constant for the namespace element MUST be:
+     * spBv1.0
+     * https://forum.cirrus-link.com/t/sparkplug-b-namespace-when-above-version-1-0/310/3
+     * The current topic token for use with Sparkplug v3.0.0 (per the spec) is still spBv1.0.
+     * Nothing fundamentally changed between v2.2 and v3.0.0 that required a change in this token.
+     */
     public static final String SPARKPLUG_CLIENT_NAME_SPACE = "spBv1.0";
 
     public static String[] getSplitTopic(String topic) {


### PR DESCRIPTION
### What is changed?

This PR updates the Sparkplug Emulator to comply with the Sparkplug TCK requirement:

**[tck-id-message-flow-phid-sparkplug-clean-session-50]**
> The CONNECT Control Packet for all Sparkplug Host Applications when using MQTT 5.0 MUST set the MQTT Clean Start flag to true and the Session Expiry Interval to 0.

### Summary of changes:
- Explicitly set `cleanStart = true` in MQTT 5.0 connection options.
- Set `sessionExpiryInterval = 0` when using MQTT 5.
- Ensures that no session state is retained by the broker between reconnects, as required by Sparkplug 3.0 spec for Edge Nodes and Host Applications.

### How to test:
- Start an MQTT 5.0 broker (e.g. Mosquitto or ThingsBoard MQTT transport).
- Run the Sparkplug Emulator with MQTT 5.0.
- Observe that CONNECT packet sets:
  - `Clean Start: true`
  - `Session Expiry Interval: 0`
- Optionally verify with Wireshark or broker logs.

### Related TCK ID:
- [tck-id-message-flow-phid-sparkplug-clean-session-50]
